### PR TITLE
Update prettier to format html files

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -46,7 +46,15 @@ module.exports = tseslint.config(
         extends: [
             ...angular.configs.templateRecommended,
             ...angular.configs.templateAccessibility,
+            eslintPluginPrettierRecommended
         ],
-        rules: {},
+        rules: {
+            'prettier/prettier': [
+                'error',
+                {
+                    'parser': 'angular',
+                }
+            ]
+        },
     },
 );

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -1,10 +1,1 @@
-<main class="main">
-  <div class="content">
-    <p class="mt-0">Hello, this is a paragraph!</p>
-    <p-button label="Click me!"/>
-    <label class="mt-4" for="password">I am a label.</label>
-    <p-password class="mt-2" id="password"/>
-  </div>
-</main>
-
 <router-outlet />

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -1,13 +1,13 @@
 <!doctype html>
 <html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>Frontend</title>
-  <base href="/">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="icon" type="image/x-icon" href="favicon.ico">
-</head>
-<body>
-  <app-root></app-root>
-</body>
+    <head>
+        <meta charset="utf-8" />
+        <title>Frontend</title>
+        <base href="/" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <link rel="icon" type="image/x-icon" href="favicon.ico" />
+    </head>
+    <body>
+        <app-root></app-root>
+    </body>
 </html>


### PR DESCRIPTION
Running prettier previously did not affect html files even though the config targeted them. This fix allows running `npm run lint` to target html files while using angular as the parser.