### PR TITLE
Add Dozzle

### DIFF
--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -43,3 +43,10 @@ services:
   match-broker:
     ports:
       - 5672:5672
+
+  dozzle:
+    image: amir20/dozzle:latest
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    ports:
+      - 8000:8080


### PR DESCRIPTION
## Description

Add Dozzle for development purposes, available on port 8000. This is a lightweight logs viewer that is more intuitive than reading Docker Desktop. This is necessary because I have given up on (and deleted) Docker Desktop. 🙏

## Checklist

- [x] I have updated documentation
- [x] All tests passing

## Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/6a953e33-c431-4696-9043-93b81106827f)
