### PR TITLE
Database per service pattern

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -10,20 +10,15 @@ USER_DB_LOCAL_URI=mongodb://user-db:27017/user
 MATCH_DB_CLOUD_URI=<FILL-THIS-IN>
 MATCH_DB_LOCAL_URI=mongodb://match-db:27017/match
 
-# Room Service
-COLLAB_DB_CLOUD_URI=mongodb+srv://<username>:<password>@cluster0.h5ukw.mongodb.net/collaboration-service?retryWrites=true&w=majority&appName=Cluster0
-COLLAB_DB_LOCAL_URI=mongodb://collaboration-db:27017/collaboration-service
-
-# Collaboration Service (Yjs Documents)
-YJS_DB_CLOUD_URI=mongodb+srv://<username>:<password>@cluster0.h5ukw.mongodb.net/yjs-documents?retryWrites=true&w=majority&appName=Cluster0
-YJS_DB_LOCAL_URI=mongodb://collaboration-db:27017/yjs-documents
+# Collaboration Service
+COLLAB_DB_CLOUD_URI=<FILL-THIS-IN>
+COLLAB_DB_LOCAL_URI=mongodb://collaboration-db:27017/collaboration
+YJS_DB_CLOUD_URI=<FILL-THIS-IN>
+YJS_DB_LOCAL_URI=mongodb://collaboration-db:27017/room
 
 # History Service
 HISTORY_DB_CLOUD_URI=<FILL-THIS-IN>
 HISTORY_DB_LOCAL_URI=mongodb://history-db:27017/history
-
-# Will use cloud MongoDB Atlas database
-ENV=PROD
 
 # Broker
 BROKER_URL=amqp://broker:5672

--- a/.env.sample
+++ b/.env.sample
@@ -1,20 +1,14 @@
 # Question Service
 QUESTION_DB_CLOUD_URI=<FILL-THIS-IN>
 QUESTION_DB_LOCAL_URI=mongodb://question-db:27017/question
-QUESTION_DB_USERNAME=user
-QUESTION_DB_PASSWORD=password
 
 # User Service
 USER_DB_CLOUD_URI=<FILL-THIS-IN>
 USER_DB_LOCAL_URI=mongodb://user-db:27017/user
-USER_DB_USERNAME=user
-USER_DB_PASSWORD=password
 
 # Match Service
 MATCH_DB_CLOUD_URI=<FILL-THIS-IN>
 MATCH_DB_LOCAL_URI=mongodb://match-db:27017/match
-MATCH_DB_USERNAME=user
-MATCH_DB_PASSWORD=password
 
 # Room Service
 COLLAB_DB_CLOUD_URI=mongodb+srv://<username>:<password>@cluster0.h5ukw.mongodb.net/collaboration-service?retryWrites=true&w=majority&appName=Cluster0

--- a/.env.sample
+++ b/.env.sample
@@ -1,3 +1,6 @@
+# This is a sample environment configuration file.
+# Copy this file to .env and replace the placeholder values with your own.
+
 # Question Service
 QUESTION_DB_CLOUD_URI=<FILL-THIS-IN>
 QUESTION_DB_LOCAL_URI=mongodb://question-db:27017/question

--- a/compose.yml
+++ b/compose.yml
@@ -50,8 +50,6 @@ services:
     environment:
       DB_CLOUD_URI: ${QUESTION_DB_CLOUD_URI}
       DB_LOCAL_URI: ${QUESTION_DB_LOCAL_URI}
-      DB_USERNAME: ${QUESTION_DB_USERNAME}
-      DB_PASSWORD: ${QUESTION_DB_PASSWORD}
       BROKER_URL: ${BROKER_URL}
       JWT_SECRET: ${JWT_SECRET}
     depends_on:
@@ -65,12 +63,8 @@ services:
   question-db:
     container_name: question-db
     image: mongo:7.0.14
-    environment:
-      MONGO_INITDB_ROOT_USERNAME: ${QUESTION_DB_USERNAME}
-      MONGO_INITDB_ROOT_PASSWORD: ${QUESTION_DB_PASSWORD}
     volumes:
       - question-db:/data/db
-      - ./services/question/init-mongo/init-mongo.js:/docker-entrypoint-initdb.d/init-mongo.js
     networks:
       - question-db-network
     command: --quiet
@@ -85,8 +79,6 @@ services:
     environment:
       DB_CLOUD_URI: ${USER_DB_CLOUD_URI}
       DB_LOCAL_URI: ${USER_DB_LOCAL_URI}
-      DB_USERNAME: ${USER_DB_USERNAME}
-      DB_PASSWORD: ${USER_DB_PASSWORD}
       JWT_SECRET: ${JWT_SECRET}
     networks:
       - gateway-network
@@ -96,9 +88,6 @@ services:
   user-db:
     container_name: user-db
     image: mongo:7.0.14
-    environment:
-      MONGO_INITDB_ROOT_USERNAME: ${USER_DB_USERNAME}
-      MONGO_INITDB_ROOT_PASSWORD: ${USER_DB_PASSWORD}
     volumes:
       - user-db:/data/db
     networks:
@@ -115,8 +104,6 @@ services:
     environment:
       DB_CLOUD_URI: ${MATCH_DB_CLOUD_URI}
       DB_LOCAL_URI: ${MATCH_DB_LOCAL_URI}
-      DB_USERNAME: ${MATCH_DB_USERNAME}
-      DB_PASSWORD: ${MATCH_DB_PASSWORD}
       JWT_SECRET: ${JWT_SECRET}
       BROKER_URL: ${BROKER_URL}
     depends_on:
@@ -130,9 +117,6 @@ services:
   match-db:
     container_name: match-db
     image: mongo:7.0.14
-    environment:
-      MONGO_INITDB_ROOT_USERNAME: ${MATCH_DB_USERNAME}
-      MONGO_INITDB_ROOT_PASSWORD: ${MATCH_DB_PASSWORD}
     volumes:
       - match-db:/data/db
     networks:

--- a/services/collaboration/.env.sample
+++ b/services/collaboration/.env.sample
@@ -1,22 +1,11 @@
-# MongoDB Cloud URI for the room service. Replace the placeholders with your MongoDB username, password, and cluster details.
-COLLAB_DB_CLOUD_URI=mongodb+srv://<username>:<password>@cluster0.h5ukw.mongodb.net/collaboration-service?retryWrites=true&w=majority&appName=Cluster0
-COLLAB_DB_LOCAL_URI=mongodb://collaboration-db:27017/collaboration-service
-
-# MongoDB Cloud URI for Yjs documents. Replace the placeholders with your MongoDB username, password, and cluster details.
-YJS_DB_CLOUD_URI=mongodb+srv://<username>:<password>@cluster0.h5ukw.mongodb.net/yjs-documents?retryWrites=true&w=majority&appName=Cluster0
-YJS_DB_LOCAL_URI=mongodb://collaboration-db:27017/yjs-documents
-
-# Broker Service
+# This is a sample environment configuration file.
+# Copy this file to .env and replace the placeholder values with your own.
+COLLAB_DB_CLOUD_URI=<FILL-THIS-IN>
+COLLAB_DB_LOCAL_URI=mongodb://collaboration-db:27017/collaboration
+YJS_DB_CLOUD_URI=<FILL-THIS-IN>
+YJS_DB_LOCAL_URI=mongodb://collaboration-db:27017/room
 BROKER_URL=amqp://broker:5672
-
-# CORS origin configuration
 CORS_ORIGIN=*
-
-# Port
 PORT=8084
-
-# Secret for creating JWT signature
 JWT_SECRET=you-can-replace-this-with-your-own-secret
-
-# Node environment
-ENV=development
+NODE_ENV=development

--- a/services/collaboration/README.md
+++ b/services/collaboration/README.md
@@ -65,8 +65,6 @@ Here are the key environment variables used in the `.env` file:
 | `COLLAB_LOCAL_MONGO_URI` | URI for connecting to the local MongoDB database for the collaboration service (room) |
 | `YJS_CLOUD_MONGO_URI`    | URI for connecting to the MongoDB Atlas database for Yjs document persistence         |
 | `YJS_LOCAL_MONGO_URI`    | URI for connecting to the local MongoDB database for Yjs document persistence         |
-| `DB_USERNAME`            | Username for the MongoDB databases (for both cloud and local environments)            |
-| `DB_PASSWORD`            | Password for the MongoDB databases (for both cloud and local environments)            |
 | `CORS_ORIGIN`            | Allowed origins for CORS (default: * to allow all origins)                            |
 | `PORT`                   | Port for the Room and Collaboration Service (default: 8084)                           |
 | `ENV`                    | Environment setting (`development` or `production`)                                   |

--- a/services/collaboration/src/services/mongodbService.ts
+++ b/services/collaboration/src/services/mongodbService.ts
@@ -18,7 +18,7 @@ const connectToRoomDB = async (): Promise<Db> => {
         if (!roomDb) {
             const client = new MongoClient(config.COLLAB_DB_URI);
             await client.connect();
-            roomDb = client.db('collaboration-service');
+            roomDb = client.db();
             console.log('Connected to the collaboration-service (room) database');
         }
         return roomDb;
@@ -41,7 +41,7 @@ const connectToYJSDB = async (): Promise<Db> => {
 
             const client = new MongoClient(config.YJS_DB_URI);
             await client.connect();
-            yjsDb = client.db('yjs-documents');
+            yjsDb = client.db();
             console.log('Connected to the YJS database');
         }
         return yjsDb;

--- a/services/history/.env.sample
+++ b/services/history/.env.sample
@@ -1,9 +1,9 @@
 # This is a sample environment configuration file.
 # Copy this file to .env and replace the placeholder values with your own.
 DB_CLOUD_URI=<FILL-THIS-IN>
-DB_LOCAL_URI=mongodb://history-db:27017/history
-JWT_SECRET=you-can-replace-this-with-your-own-secret
+DB_LOCAL_URI=mongodb://history-db:27017/histor
 BROKER_URL=amqp://broker:5672
 CORS_ORIGIN=*
 PORT=8086
+JWT_SECRET=you-can-replace-this-with-your-own-secret
 NODE_ENV=development

--- a/services/history/.env.sample
+++ b/services/history/.env.sample
@@ -1,7 +1,7 @@
 # This is a sample environment configuration file.
 # Copy this file to .env and replace the placeholder values with your own.
 DB_CLOUD_URI=<FILL-THIS-IN>
-DB_LOCAL_URI=mongodb://history-db:27017/histor
+DB_LOCAL_URI=mongodb://history-db:27017/history
 BROKER_URL=amqp://broker:5672
 CORS_ORIGIN=*
 PORT=8086

--- a/services/match/.env.sample
+++ b/services/match/.env.sample
@@ -3,6 +3,7 @@
 DB_CLOUD_URI=<FILL-THIS-IN>
 DB_LOCAL_URI=mongodb://match-db:27017/match
 BROKER_URL=amqp://broker:5672
-JWT_SECRET=you-can-replace-this-with-your-own-secret
+CORS_ORIGIN=*
 PORT=8083
+JWT_SECRET=you-can-replace-this-with-your-own-secret
 NODE_ENV=development

--- a/services/match/.env.sample
+++ b/services/match/.env.sample
@@ -2,8 +2,6 @@
 # Copy this file to .env and replace the placeholder values with your own.
 DB_CLOUD_URI=<FILL-THIS-IN>
 DB_LOCAL_URI=mongodb://match-db:27017/match
-DB_USERNAME=user
-DB_PASSWORD=password
 BROKER_URL=amqp://broker:5672
 JWT_SECRET=you-can-replace-this-with-your-own-secret
 PORT=8083

--- a/services/match/src/config.ts
+++ b/services/match/src/config.ts
@@ -2,8 +2,6 @@ import { z } from 'zod';
 
 const envSchema = z
     .object({
-        DB_USERNAME: z.string().trim().min(1),
-        DB_PASSWORD: z.string().trim().min(1),
         DB_CLOUD_URI: z.string().trim().optional(),
         DB_LOCAL_URI: z.string().trim().optional(),
         BROKER_URL: z.string().url(),

--- a/services/match/src/models/repository.ts
+++ b/services/match/src/models/repository.ts
@@ -5,11 +5,7 @@ import config from '../config';
 import { IdType } from '../types/request';
 
 export async function connectToDB() {
-    await mongoose.connect(config.DB_URI, {
-        authSource: 'admin',
-        user: config.DB_USERNAME,
-        pass: config.DB_PASSWORD,
-    });
+    await mongoose.connect(config.DB_URI);
 }
 
 export async function createMatchRequest(userId: IdType, username: string, topics: string[], difficulty: Difficulty) {

--- a/services/question/.env.sample
+++ b/services/question/.env.sample
@@ -2,8 +2,6 @@
 # Copy this file to .env and replace the placeholder values with your own.
 DB_CLOUD_URI=<FILL-THIS-IN>
 DB_LOCAL_URI=mongodb://question-db:27017/question
-DB_USERNAME=user
-DB_PASSWORD=password
 BROKER_URL=amqp://broker:5672
 JWT_SECRET=you-can-replace-this-with-your-own-secret
 CORS_ORIGIN=*

--- a/services/question/.env.sample
+++ b/services/question/.env.sample
@@ -3,7 +3,7 @@
 DB_CLOUD_URI=<FILL-THIS-IN>
 DB_LOCAL_URI=mongodb://question-db:27017/question
 BROKER_URL=amqp://broker:5672
-JWT_SECRET=you-can-replace-this-with-your-own-secret
 CORS_ORIGIN=*
 PORT=8081
+JWT_SECRET=you-can-replace-this-with-your-own-secret
 NODE_ENV=development

--- a/services/question/src/config.ts
+++ b/services/question/src/config.ts
@@ -2,8 +2,6 @@ import { z } from 'zod';
 
 const envSchema = z
     .object({
-        DB_USERNAME: z.string().trim().min(1),
-        DB_PASSWORD: z.string().trim().min(1),
         DB_CLOUD_URI: z.string().trim().optional(),
         DB_LOCAL_URI: z.string().trim().optional(),
         BROKER_URL: z.string().url(),

--- a/services/question/src/init-mongo/init-mongo.js
+++ b/services/question/src/init-mongo/init-mongo.js
@@ -1,5 +1,0 @@
-db.createUser({
-    user: "user",
-    pwd: "password",
-    roles: [{ role: "root", db: "admin" }]
-});

--- a/services/question/src/models/index.ts
+++ b/services/question/src/models/index.ts
@@ -3,11 +3,7 @@ import { IQuestion, Question } from './questionModel';
 import config from '../config';
 
 export async function connectToDB() {
-    await mongoose.connect(config.DB_URI, {
-        authSource: 'admin',
-        user: config.DB_USERNAME,
-        pass: config.DB_PASSWORD,
-    });
+    await mongoose.connect(config.DB_URI);
 }
 
 export async function upsertManyQuestions(questions: IQuestion[]) {

--- a/services/user/.env.sample
+++ b/services/user/.env.sample
@@ -3,8 +3,5 @@
 DB_CLOUD_URI=<FILL-THIS-IN>
 DB_LOCAL_URI=mongodb://user-db:27017/user
 PORT=8083
-
-# Secret for creating JWT signature
 JWT_SECRET=you-can-replace-this-with-your-own-secret
-
 NODE_ENV=development

--- a/services/user/src/config.ts
+++ b/services/user/src/config.ts
@@ -2,8 +2,6 @@ import { z } from 'zod';
 
 const envSchema = z
     .object({
-        DB_USERNAME: z.string().trim().min(1),
-        DB_PASSWORD: z.string().trim().min(1),
         DB_CLOUD_URI: z.string().trim().optional(),
         DB_LOCAL_URI: z.string().trim().optional(),
         NODE_ENV: z.enum(['development', 'production']).default('development'),

--- a/services/user/src/model/repository.ts
+++ b/services/user/src/model/repository.ts
@@ -4,11 +4,7 @@ import { connect } from 'mongoose';
 import config from '../config';
 
 export async function connectToDB() {
-    await connect(config.DB_URI, {
-        authSource: 'admin',
-        user: config.DB_USERNAME,
-        pass: config.DB_PASSWORD,
-    });
+    await connect(config.DB_URI);
 }
 
 export async function createUser(username: string, email: string, password: string) {


### PR DESCRIPTION
## Description

Currently all services specify their databases, but on production, they share the full database server without restrictions. Ideally, we would like to implement database-per-service pattern, where data independence is ensured. At the same time, we would like the services to share the same database server, to reduce costs. Hence, we shall enforce these restrictions at the database level using different database users (see [this](https://stackoverflow.com/a/78806035/23542328)).

Let's,
* Update the database selection to be dynamically configured through environment variables instead of hardcoded. 
* Remove username and passwords on the Docker databases. Docker is used for **development only** and does not require authentication. Fixes #35.
* Streamline environment files

## Checklist

- [X] I have updated documentation
- [X] All tests passing

## Screenshots (if applicable)
<img width="781" alt="Screenshot 2024-11-08 004634" src="https://github.com/user-attachments/assets/bb06edf7-b0f4-4ef4-a372-ac139c1127dc">
