### PR TITLE
Minor Fix on the Collaboration Service

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -28,9 +28,6 @@ YJS_DB_LOCAL_URI=mongodb://collaboration-db:27017/yjs-documents
 HISTORY_DB_CLOUD_URI=<FILL-THIS-IN>
 HISTORY_DB_LOCAL_URI=mongodb://history-db:27017/history
 
-# Will use cloud MongoDB Atlas database
-ENV=PROD
-
 # Broker
 BROKER_URL=amqp://broker:5672
 

--- a/services/collaboration/src/controllers/roomController.ts
+++ b/services/collaboration/src/controllers/roomController.ts
@@ -154,6 +154,7 @@ export const updateUserStatusInRoomController = async (req: Request, res: Respon
 
         // Check if all users in the room have forfeited
         const allUsersForfeited = updatedRoom.users.every(user => user.isForfeit === true);
+        console.log('All users forfeited check:', allUsersForfeited, updatedRoom.users);
         if (allUsersForfeited) {
             // Close the room if both users have forfeited
             const result = await closeRoomById(roomId);

--- a/services/collaboration/src/services/mongodbService.ts
+++ b/services/collaboration/src/services/mongodbService.ts
@@ -108,6 +108,22 @@ export const findRoomById = async (roomId: string, userId: string): Promise<With
 };
 
 /**
+ * Check if a Yjs document exists in the MongoDB Yjs database
+ * @param roomId
+ * @returns {Promise<boolean>}
+ */
+export const yjsDocumentExists = async (roomId: string): Promise<boolean> => {
+    try {
+        const db = await connectToYJSDB();
+        const collectionInfo = await db.collection(roomId).findOne({});
+        return collectionInfo !== null;
+    } catch (error) {
+        console.error(`Error checking for Yjs document existence for room ID ${roomId}:`, error);
+        throw error;
+    }
+};
+
+/**
  * Create and bind a Yjs document using the room_id as the document name
  * @param roomId
  * @returns
@@ -132,9 +148,10 @@ export const createYjsDocument = async (roomId: string) => {
  */
 export const deleteYjsDocument = async (roomId: string) => {
     try {
+        console.log(`Attempting to delete Yjs document collection for room: ${roomId}`);
         const db = await connectToYJSDB();
-        await db.collection(roomId).drop();
-        console.log(`Yjs document collection for room ${roomId} deleted`);
+        const result = await db.collection(roomId).drop();
+        console.log(`Yjs document collection for room ${roomId} deleted successfully: ${result}`);
     } catch (error) {
         console.error(`Failed to delete Yjs document for room ${roomId}:`, error);
         throw error;
@@ -196,6 +213,12 @@ export const closeRoomById = async (roomId: string) => {
     }
 };
 
+/**
+ * Update the user isForfeit status in a room
+ * @param roomId
+ * @param userId
+ * @param isForfeit
+ */
 export const updateRoomUserStatus = async (roomId: string, userId: string, isForfeit: boolean) => {
     try {
         const db = await connectToRoomDB();

--- a/services/collaboration/src/services/mongodbService.ts
+++ b/services/collaboration/src/services/mongodbService.ts
@@ -108,22 +108,6 @@ export const findRoomById = async (roomId: string, userId: string): Promise<With
 };
 
 /**
- * Check if a Yjs document exists in the MongoDB Yjs database
- * @param roomId
- * @returns {Promise<boolean>}
- */
-export const yjsDocumentExists = async (roomId: string): Promise<boolean> => {
-    try {
-        const db = await connectToYJSDB();
-        const collectionInfo = await db.collection(roomId).findOne({});
-        return collectionInfo !== null;
-    } catch (error) {
-        console.error(`Error checking for Yjs document existence for room ID ${roomId}:`, error);
-        throw error;
-    }
-};
-
-/**
  * Create and bind a Yjs document using the room_id as the document name
  * @param roomId
  * @returns


### PR DESCRIPTION
## Description

- Fix the part where the room is initialised as api/collaboration/room_id to only room_id
- Added a guard clause to prevent the user from accessing the room if the YJS docs is not present (check using room_id since the YJS docs collection name is the room_id itself)
- Remove the ENV=PROD inside the env sample (I think we are using the NODE_ENV rather than ENV)

## Checklist

- [ ] I have updated documentation
- [ ] All tests passing

## Screenshots (if applicable)
![photo_2024-11-08 15 35 02](https://github.com/user-attachments/assets/bcc5bd01-f417-4a87-a1d6-2c3bc072c702)